### PR TITLE
Option to import bookmark folders as tags

### DIFF
--- a/index.php
+++ b/index.php
@@ -1677,7 +1677,12 @@ function importFile()
                 {
                     $attr=$m[1]; $value=$m[2];
                     if ($attr=='HREF') $link['url']=html_entity_decode($value,ENT_QUOTES,'UTF-8');
-                    elseif ($attr=='ADD_DATE') $raw_add_date=intval($value);
+                    elseif ($attr=='ADD_DATE')
+                    {
+                        $raw_add_date = floatval($value);
+                        // Adjust date from microseconds to seconds if necessary
+                        $raw_add_date = intval($raw_add_date > 1e15 ? $raw_add_date / 1E6 : $raw_add_date);
+                    }
                     elseif ($attr=='PRIVATE') $link['private']=($value=='0'?0:1);
                     elseif ($attr=='TAGS') $link['tags']=html_entity_decode(str_replace(',',' ',$value),ENT_QUOTES,'UTF-8');
                 }

--- a/index.php
+++ b/index.php
@@ -1683,7 +1683,6 @@ function importFile()
                 }
                 if (empty($link['tags']) and $usefolders)
                 {
-                    $filename = 'YESS';
                     $link['tags'] = str_replace(',',' ',$cur_folder);
                 }
                 if ($link['url']!='')
@@ -1717,7 +1716,6 @@ function importFile()
             }
             elseif (startswith($d[0],'<H3 '))
             {
-                $filesize = 'TESS';
                 // Use folder as tag for the following links
                 preg_match('!<H3 .*?>(.*?)</H3>!i',$d[0],$matches);
                 $cur_folder = (isset($matches[1]) ? trim($matches[1]) : '');  // Get folder name

--- a/index.php
+++ b/index.php
@@ -1707,6 +1707,9 @@ function importFile()
                         if ($overwrite)
                         {   // If overwrite is required, we import link data, except date/time.
                             $link['linkdate']=$dblink['linkdate'];
+                            // Additionally, merge old tags instead of dropping them
+                            $mtags = array_merge(explode(' ',$link['tags']),explode(' ',$dblink['tags']));
+                            $link['tags'] = implode(' ',array_unique($mtags));
                             $LINKSDB[$link['linkdate']] = $link;
                             $import_count++;
                         }

--- a/tpl/import.html
+++ b/tpl/import.html
@@ -12,7 +12,8 @@
 	    <input type="hidden" name="MAX_FILE_SIZE" value="{$maxfilesize|htmlspecialchars}">
 	    <input type="submit" name="import_file" value="Import" class="bigbutton"><br>
 	    <input type="checkbox" name="private" id="private"><label for="private">&nbsp;Import all links as private</label><br>
-	    <input type="checkbox" name="overwrite" id="overwrite"><label for="overwrite">&nbsp;Overwrite existing links</label>
+	    <input type="checkbox" name="overwrite" id="overwrite"><label for="overwrite">&nbsp;Overwrite existing links</label><br>
+	    <input type="checkbox" name="usefolders" id="usefolders"><label for="usefolders">&nbsp;Use folders as tags</label>
 	</form>
 	</div>
 </div>


### PR DESCRIPTION
There is no standard way of export tags in Netscape's bookmarks file format. When exporting from Google Bookmarks, folders are used as tags. The following example shows a bookmark that was tagged with **History** and **Programming**:

``` html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks</H1>
<DL><p>
  <DT><H3 ADD_DATE="1258826211990949">History</H3>
  <DL><p>
    <DT><A HREF="http://dotnetmasters.com/historyofcfamily.htm" ADD_DATE="1260914469588170">History of the C family of languages</A>
  </DL><p>
  <DT><H3 ADD_DATE="1238826211990949">Programming</H3>
  <DL><p>
    <DT><A HREF="http://dotnetmasters.com/historyofcfamily.htm" ADD_DATE="1260914469588170">History of the C family of languages</A>
  </DL><p>
</DL><p>
```

In order to support imports from Google Bookmarks (and other services which use folders during the export), I added an option to the import form which uses the folders as tags. For bookmarks with multiple tags the **overwrite** options needs to be enabled as well. Additionally, the timestamp needs to be adjusted from microseconds to normal unix seconds during the import.

![import](https://f.cloud.github.com/assets/479238/406964/1df90952-aacc-11e2-950b-10b714c82cec.png)

The result of a successful import has the right tags for all imported links:

![result](https://f.cloud.github.com/assets/479238/406967/7b69a5f6-aacc-11e2-8430-46ac0dab3fc0.png)
