### PR TITLE
Ajout d’un UA lors de la récupération d’une page externe

### DIFF
--- a/index.php
+++ b/index.php
@@ -566,7 +566,7 @@ function getHTTP($url,$timeout=30)
 {
     try
     {
-        $options = array('http'=>array('method'=>'GET','timeout' => $timeout)); // Force network timeout
+        $options = array('http'=>array('method'=>'GET','timeout' => $timeout, 'user_agent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:23.0) Gecko/20100101 Firefox/23.0')); // Force network timeout
         $context = stream_context_create($options);
         $data=file_get_contents($url,false,$context,-1, 4000000); // We download at most 4 Mb from source.
         if (!$data) { return array('HTTP Error',array(),''); }


### PR DESCRIPTION
Certains sites veulent un UA, exemple pour ce lien : http://www.ldlc.com/fiche/PB00151866.html

Sans UA, on tombe sur une page disant que l’IP est bannie. Avec un UA (même bidon, mais pas vide) ça marche. Suffit de tester avec WGET : 
// ceci marche :
wget --user-agent='firefox' http://www.ldlc.com/fiche/PB00151866.html
// ceci ne marche pas : (ça récupère une page "ip bannies")
wget http://www.ldlc.com/fiche/PB00151866.html

Au cas où, j’ai mis l’UA de Firefox 23 sous Ubuntu.
