### PR TITLE
Added the possibility to put a description in the bookmarklet's URL

### DIFF
--- a/index.php
+++ b/index.php
@@ -1538,7 +1538,8 @@ function renderPage()
             $link_is_new = true;  // This is a new link
             $linkdate = strval(date('Ymd_His'));
             $title = (empty($_GET['title']) ? '' : $_GET['title'] ); // Get title if it was provided in URL (by the bookmarklet).
-            $description=''; $tags=''; $private=0;
+            $description = (empty($_GET['description']) ? '' : $_GET['description'] )."\n"; // Get description if it was provided in URL (by the bookmarklet). [Bronco added that]
+            $tags=''; $private=0;
             if (($url!='') && parse_url($url,PHP_URL_SCHEME)=='') $url = 'http://'.$url;
             // If this is an HTTP link, we try go get the page to extact the title (otherwise we will to straight to the edit form.)
             if (empty($title) && parse_url($url,PHP_URL_SCHEME)=='http')


### PR DESCRIPTION
Salut Seb,
Je bossais sur Sonar'RSS et je voulais modifier la fonction "répondre via shaarli" pour pouvoir préciser le lien vers le message précédent dans la description; j'ai donc eu besoin d'ajouter la possibilité de mettre la description dans l'URL d'appel du bookmarklet.
J'ai fait la petite modif nécessaire et je te la propose si tu as envie de l'ajouter à ta version ;)
N'hésite pas à commenter si t'as deux minutes (work and kids overflow mode off ? hinhin )
A plus tard
Bronco
