### PR TITLE
Import: add compatibility for milliseconds in NETSCAPE-Bookmark

### DIFF
--- a/index.php
+++ b/index.php
@@ -1695,7 +1695,11 @@ function importFile()
                 {
                     $attr=$m[1]; $value=$m[2];
                     if ($attr=='HREF') $link['url']=html_entity_decode($value,ENT_QUOTES,'UTF-8');
-                    elseif ($attr=='ADD_DATE') $raw_add_date=intval($value);
+                    elseif ($attr=='ADD_DATE')
+                    {
+                        $raw_add_date=intval($value);
+                        if ($raw_add_date>30000000000) $raw_add_date/=1000;	//If larger than year 2920, then was likely stored in milliseconds instead of seconds
+                    }
                     elseif ($attr=='PRIVATE') $link['private']=($value=='0'?0:1);
                     elseif ($attr=='TAGS') $link['tags']=html_entity_decode(str_replace(',',' ',$value),ENT_QUOTES,'UTF-8');
                 }


### PR DESCRIPTION
NETSCAPE-Bookmark sometimes contains dates as milliseconds instead of seconds.
For instance, this is the case for the files generated for Google +1s by Google Takeout.
This patch make these files compatible.

Example of such a file generated from Google +1s:

``` html
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks</H1>
<DL><p>
<DT><H3>Google +1s</H3>
<DL><p>
    <DT><A HREF="http://www.engadget.com/2013/06/17/airbus-a350-cockpit-video-tour/" ADD_DATE="1376683982550" LAST_MODIFIED="1376683982550">Airbus A350 cockpit tour with test pilot Jean-Michel Roy (video)</A>
</DL><p>
```
