### PR TITLE
Skip webserver port detection if running behind a reverse proxy

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,6 +29,7 @@ $GLOBALS['config']['PUBSUBHUB_URL'] = ''; // PubSubHubbub support. Put an empty 
 $GLOBALS['config']['UPDATECHECK_FILENAME'] = $GLOBALS['config']['DATADIR'].'/lastupdatecheck.txt'; // For updates check of Shaarli.
 $GLOBALS['config']['UPDATECHECK_INTERVAL'] = 86400 ; // Updates check frequency for Shaarli. 86400 seconds=24 hours
                                           // Note: You must have publisher.php in the same directory as Shaarli index.php
+$GLOBALS['config']['REVERSE_PROXY_PORT'] = 0; // 0 : no reverse proxy. >0 : the port listened to by the reverse proxy.
 // -----------------------------------------------------------------------------------------------
 // You should not touch below (or at your own risks !)
 // Optionnal config file.
@@ -451,7 +452,13 @@ if (isset($_POST['login']))
 function serverUrl()
 {
     $https = (!empty($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS'])=='on')) || $_SERVER["SERVER_PORT"]=='443'; // HTTPS detection.
-    $serverport = ($_SERVER["SERVER_PORT"]=='80' || ($https && $_SERVER["SERVER_PORT"]=='443') ? '' : ':'.$_SERVER["SERVER_PORT"]);
+
+    if ($GLOBALS['config']['REVERSE_PROXY_PORT']) {
+        $serverport = ':'.$GLOBALS['config']['REVERSE_PROXY_PORT'];
+    }
+    else {
+        $serverport = ($_SERVER["SERVER_PORT"]=='80' || ($https && $_SERVER["SERVER_PORT"]=='443') ? '' : ':'.$_SERVER["SERVER_PORT"]);
+    }
     return 'http'.($https?'s':'').'://'.$_SERVER['HTTP_HOST'].$serverport;
 }
 


### PR DESCRIPTION
When running Shaarli behind a reverse proxy, Ajax-based functions (such as autocomplete of shaarlink tags) stops working.
- BEFORE installing the reverse proxy : the webserver is accessible from the Internet directly on port 80. This port is also detected by the "serverUrl" function. Ajax requests are sent there for autocomplete of tags : http://shaarli.domain.tld/?ws=tags&term=<search terms>
- AFTER installing the reverse proxy : the webserver is listening on port 8080 (or any other port : this is some webserver-internal stuff), and it's listening to the reverse proxy exclusively. The reverse proxy itself is listening on port 80. It such case, the "serverUrl" function detects "8080" as the server port, and Ajax queries are sent to http://shaarli.domain.tld:8080/?ws=tags&term=<search terms> , where nobody's publicly listening. Then no more autocompletes :-(

The change I've made tries to circumvent this : if no reverse proxy port is declared, let's keep the previous behaviour (autodetect the server port). Otherwise, use the provided reverse proxy port (mostly 80) to build the destination addresses :

http://shaarli.domain.tld:<port>/?ws=tags&term=<search terms>
